### PR TITLE
Dynamic Maya Mesh Data input for Pies

### DIFF
--- a/Include/SolverNode.h
+++ b/Include/SolverNode.h
@@ -34,6 +34,7 @@ public:
   static MTypeId id;
   static MObject time;
   static MObject prevTime;
+  static MObject inputMesh;
   static MObject stepSize;
   static MObject iterations;
   static MObject simulationEnabled;

--- a/Src/SolverNode.cpp
+++ b/Src/SolverNode.cpp
@@ -7,6 +7,7 @@
 #include <maya/MFnMeshData.h>
 #include <maya/MFnNumericAttribute.h>
 #include <maya/MFnStringData.h>
+#include <maya/MFnMeshData.h>
 #include <maya/MFnUnitAttribute.h>
 #include <maya/MGlobal.h>
 #include <maya/MIOStream.h>
@@ -323,6 +324,18 @@ MStatus SolverNode::initialize() {
   status = addAttribute(SolverNode::prevTime);
   McheckErr(status, "ERROR adding attribute SolverNode::prevTime.");
 
+  MFnTypedAttribute inputMeshAttr;
+  SolverNode::inputMesh =
+      inputMeshAttr.create("inputMesh", "mesh", MFnMeshData::kMesh, MObject::kNullObj, &status);
+  McheckErr(status, "ERROR creating attribute SolverNode::inputMesh.");
+
+  inputMeshAttr.setWritable(true);
+  inputMeshAttr.setStorable(true);
+  inputMeshAttr.setReadable(true);
+  inputMeshAttr.setKeyable(true);
+  status = addAttribute(SolverNode::inputMesh);
+  McheckErr(status, "ERROR adding attribute SolverNode::inputMesh.");
+
   MFnNumericAttribute stepSizeAttr;
   SolverNode::stepSize =
       stepSizeAttr
@@ -390,6 +403,9 @@ MStatus SolverNode::initialize() {
   // Setup input-output dependencies
   status = attributeAffects(time, ouptutPositions);
   McheckErr(status, "ERROR attributeAffects(time, ouptutPositions).");
+
+  status = attributeAffects(inputMesh, ouptutPositions);
+  McheckErr(status, "ERROR attributeAffects(inputMesh, ouptutPositions).");
 
   status = attributeAffects(stepSize, ouptutPositions);
   McheckErr(status, "ERROR attributeAffects(stepSize, ouptutPositions).");

--- a/Src/SolverNode.cpp
+++ b/Src/SolverNode.cpp
@@ -176,7 +176,7 @@ MStatus SolverNode::compute(const MPlug& plug, MDataBlock& data) {
 
       for (int i = 0; i < meshVerts.length(); ++i) {
         //Add vertices to Pies as unconnected nodes
-        continue;
+        MPoint currVert = meshVerts[i];
       }
     }
 

--- a/Src/SolverNode.cpp
+++ b/Src/SolverNode.cpp
@@ -42,6 +42,9 @@ MObject SolverNode::time;
 MObject SolverNode::prevTime;
 
 /*static*/
+MObject SolverNode::inputMesh;
+
+/*static*/
 MObject SolverNode::stepSize;
 
 /*static*/
@@ -130,6 +133,9 @@ MStatus SolverNode::compute(const MPlug& plug, MDataBlock& data) {
     MDataHandle outputPrevTimeHandle = data.outputValue(prevTime, &status);
     McheckErr(status, "ERROR getting output prevTime handle.");
 
+    MDataHandle inputMeshHandle = data.inputValue(inputMesh, &status);
+    McheckErr(status, "ERROR getting output inputMesh handle.");
+
     MDataHandle stepSizeHandle = data.inputValue(stepSize, &status);
     McheckErr(status, "ERROR getting step size handle.");
 
@@ -149,6 +155,8 @@ MStatus SolverNode::compute(const MPlug& plug, MDataBlock& data) {
     MTime currentTime = timeHandle.asTime();
     const MTime previousTime = prevTimeHandle.asTime();
 
+    MFnMesh inputMesh = inputMeshHandle.asMesh();
+
     // if (currentTime == previousTime) {
     //   // TODO: ??
     //   data.setClean(ouptutPositions);
@@ -160,6 +168,18 @@ MStatus SolverNode::compute(const MPlug& plug, MDataBlock& data) {
     bool simulationEnabledValue = simulationEnabledHandle.asBool();
     float currentStepSize = stepSizeHandle.asFloat();
     int currentIters = itersHandle.asInt();
+    
+    // Add mesh to Pies if simulation is disabled
+    if (!simulationEnabledValue) {
+      MPointArray meshVerts;
+      inputMesh.getPoints(meshVerts);
+
+      for (int i = 0; i < meshVerts.length(); ++i) {
+        //Add vertices to Pies as unconnected nodes
+        continue;
+      }
+    }
+
 
     if (simulationEnabledValue && this->_simulationTime < timeSeconds) {
       // TODO: Is this correct??


### PR DESCRIPTION
These changes should eventually allow us to input meshes created in a Maya scene into the Pies solver. 

The current changes only reflect an `inputMesh` attribute with no functionality.